### PR TITLE
Allow scripts started/stopped from the script GUI to change the running scripts in the database.

### DIFF
--- a/Source/Main Dialogs/TaskMaster/ORTask.h
+++ b/Source/Main Dialogs/TaskMaster/ORTask.h
@@ -82,6 +82,9 @@
 - (void) addExtraPanel:(NSView*)aView;
 - (BOOL) isSlave;
 - (void) setIsSlave:(BOOL)state;
+- (NSButton*) getStartButton;
+- (NSTextField*) getRunStateField;
+- (NSTextField*) getNextRunTimeField;
 
 #pragma mark ¥¥¥Actions
 -(IBAction) startAction:(id)sender;

--- a/Source/Main Dialogs/TaskMaster/ORTask.m
+++ b/Source/Main Dialogs/TaskMaster/ORTask.m
@@ -301,6 +301,21 @@ NSString* ORTaskDidFinishNotification   = @"ORTaskDidFinishNotification";
     }
 }
 
+- (NSButton*) getStartButton
+{
+    return startButton;
+}
+
+- (NSTextField*) getRunStateField
+{
+    return runStateField;
+}
+
+- (NSTextField*) getNextRunTimeField
+{
+    return nextRunTimeField;
+}
+
 #pragma mark •••Actions
 -(IBAction) detailsAction:(id)sender 
 {

--- a/Source/Main Dialogs/TaskMaster/ORTaskMaster.m
+++ b/Source/Main Dialogs/TaskMaster/ORTaskMaster.m
@@ -153,18 +153,36 @@ SYNTHESIZE_SINGLETON_FOR_ORCLASS(TaskMaster);
 
 - (void) taskStarted:(NSNotification*)aNote
 {
+    // add task to list of running tasks
 	if(!runningTasks)runningTasks = [[NSMutableArray alloc] init];
 	[runningTasks addObject:[aNote object]];
+    // if this is an ORScriptInterface, it was started from the script GUI, make the view consistent with running status
+    if([[aNote object] isKindOfClass:[ORScriptInterface class]]){
+        ORScriptInterface* task = [aNote object];
+        [[task getStartButton] setTitle:@"Stop"];
+        [[task getRunStateField] setStringValue:@"Running"];
+        [[task getNextRunTimeField] setStringValue:@"Now"];
+    }
+    // update the running task list in the database if option is selected in couchdb
 	[self postRunningTaskList];
 }
 
 - (void) taskStopped:(NSNotification*)aNote
 {
+    // if this is an ORScriptInterface, it was started from the script GUI, make the view consistent with running status
+    if([[aNote object] isKindOfClass:[ORScriptInterface class]]){
+        ORScriptInterface* task = [aNote object];
+        [[task getStartButton] setTitle:@"Start"];
+        [[task getRunStateField] setStringValue:@"Stopped"];
+        [[task getNextRunTimeField] setStringValue:@"Not Scheduled"];
+    }
+    // remove object from list of running tasks
 	[runningTasks removeObject:[aNote object]];
 	if([runningTasks count] == 0){
 		[runningTasks release];
 		runningTasks = nil;
 	}
+    // update the running task list in the database if option is selected in couchdb
 	[self postRunningTaskList];
 }
 

--- a/Source/Main Dialogs/TaskMaster/ScriptTask/ScriptInterfaceTask/ORScriptInterface.m
+++ b/Source/Main Dialogs/TaskMaster/ScriptTask/ScriptInterfaceTask/ORScriptInterface.m
@@ -103,8 +103,14 @@
 
 - (void) runningChanged:(NSNotification*)aNote
 {
-	if([[delegate scriptRunner] running])[self setMessage:@"Running"];
-	else [self setMessage:@"Idle"];
+    if([[delegate scriptRunner] running]){
+        [self setMessage:@"Running"];
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORTaskDidStartNotification object:self];
+    }
+    else{
+        [self setMessage:@"Idle"];
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORTaskDidFinishNotification object:self];
+    }
 }
 
 #pragma mark ¥¥¥Actions


### PR DESCRIPTION
Previously, the CouchDB entry for the TaskMaster would only update the list of running scripts if the script tasks were started from the TaskMaster object.  Now the status of scripts started/stopped in the script GUI will be reflected in the TaskMaster object correctly, and updates to the CouchDB TaskMaster entry will be posted if the global option to post the contents of running scripts is selected in the CouchDB object.