### PR TITLE
fix crash at run start when no hardware

### DIFF
--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/ORFlashCamListenerModel.m
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/ORFlashCamListenerModel.m
@@ -775,8 +775,8 @@ NSString* ORFlashCamListenerModelStatusBufferFull = @"ORFlashCamListenerModelSta
     }
     NSString* s = [NSString stringWithFormat:@"tcp://listen/%d/%@", port, ip];
     reader = FCIOCreateStateReader([s UTF8String], timeout, ioBuffer, stateBuffer);
-    FCIOSelectStateTag(reader, 0);
     if(reader){
+        FCIOSelectStateTag(reader, 0);
         [self setUpImage];
 
         NSLog(@"ORFlashCamListenerModel: connected to %@:%d on %@\n", ip, port, interface);


### PR DESCRIPTION
moved FCIOSelectStateTag(reader, 0); to after the check is reader in non-nil