### PR TITLE
ORHVcRIOModel: More digits

### DIFF
--- a/Source/Objects/Hardware/Internet/HVcRIO/ORHVcRIOModel.m
+++ b/Source/Objects/Hardware/Internet/HVcRIO/ORHVcRIOModel.m
@@ -1014,13 +1014,13 @@ static NSString* itemsToShip[kNumToShip*2] = {
 {
     NSNumber* oldValue = [[setPoints objectAtIndex:aIndex] objectForKey:@"setPoint"];
     [[[self undoManager] prepareWithInvocationTarget:self] setSetPoint:aIndex withValue:[oldValue floatValue]];
-    [[setPoints objectAtIndex:aIndex] setObject:[NSString stringWithFormat:@"%.6f",value] forKey:@"setPoint"];
+    [[setPoints objectAtIndex:aIndex] setObject:[NSString stringWithFormat:@"%.8f",value] forKey:@"setPoint"];
     [[NSNotificationCenter defaultCenter] postNotificationName:ORHVcRIOModelSetPointChanged object:self];
 }
 
 - (void) setSetPointReadback: (int)aIndex withValue: (double)value
 {
-    [[setPoints objectAtIndex:aIndex] setObject:[NSString stringWithFormat:@"%.6f",value] forKey:@"readBack"];
+    [[setPoints objectAtIndex:aIndex] setObject:[NSString stringWithFormat:@"%.8f",value] forKey:@"readBack"];
     [[NSNotificationCenter defaultCenter] postNotificationName:ORHVcRIOModelSetPointChanged object:self];
 }
 


### PR DESCRIPTION
Add digits to values in `ORHVcRIOModel`. At KATRIN, we need to set some values with further precision than is possible with the HV object at the moment - 8 digits should be enough. This is relevant especially because of `SOLL_EHV#postReg`, in which this discretization limited our ability to set this value precisely. If there is no reason against using the maximal amount of digits, we could also go to `"%lf` as is done in `setMeasuredValue`?