### PR TITLE
Changed boolean fields and tags to use the influxdb data types

### DIFF
--- a/Source/Objects/Misc Objects/InFluxDB/ORInFluxDBCmd.m
+++ b/Source/Objects/Misc Objects/InFluxDB/ORInFluxDBCmd.m
@@ -174,7 +174,7 @@
 {
     NSString* requestString = [NSString stringWithFormat:@"%@/api/v2/orgs",[delegate hostName]];
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:requestString]];
-    
+
     request.HTTPMethod = @"GET";
     [request setValue:[NSString stringWithFormat:@"Token %@",[delegate authToken]] forHTTPHeaderField:@"Authorization"];
     requestSize = [requestString length];
@@ -200,7 +200,7 @@
 {
     NSString* requestString = [NSString stringWithFormat:@"%@/api/v2/orgs",[delegate hostName]];
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:requestString]];
-    
+
     request.HTTPMethod = @"GET";
     [request setValue:[NSString stringWithFormat:@"Token %@",[delegate authToken]] forHTTPHeaderField:@"Authorization"];
     requestSize = [requestString length];
@@ -337,7 +337,7 @@
 
 - (void) addTag:(NSString*)aLabel withBoolean:(BOOL)aValue
 {
-    [tags addObject:[NSString stringWithFormat:@"%@=%d",aLabel,aValue]];
+    [tags addObject:[NSString stringWithFormat:@"%@=%@",aLabel,aValue?@"true":@"false"]];
 }
 
 - (void) addTag:(NSString*)aLabel withLong:(long)aValue
@@ -352,12 +352,12 @@
 
 - (void) addField:(NSString*)aValueName withBoolean:(BOOL)aValue
 {
-    [measurements addObject:[NSString stringWithFormat:@"%@=%d",aValueName,aValue]];
+    [measurements addObject:[NSString stringWithFormat:@"%@=%@",aValueName,aValue?@"true":@"false"]];
 }
 
 - (void) addField:(NSString*)aValueName withLong:(long)aValue
 {
-    [measurements addObject:[NSString stringWithFormat:@"%@=%ld",aValueName,aValue]];
+    [measurements addObject:[NSString stringWithFormat:@"%@=%ldi",aValueName,aValue]];
 }
 
 - (void) addField:(NSString*)aValueName withDouble:(double)aValue
@@ -379,11 +379,11 @@
 {
     NSString* requestString = [NSString stringWithFormat:@"%@/api/v2/write?org=%@&bucket=%@&precision=ns",[delegate hostName],org,bucket];
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:requestString]];
-    
+
     request.HTTPMethod = @"POST";
     [request setValue:@"text/plain; application/json" forHTTPHeaderField:@"Accept"];
     [request setValue:[NSString stringWithFormat:@"Token %@",[delegate authToken]]                     forHTTPHeaderField:@"Authorization"];
-    
+
     NSString* outputBuffer = [NSString stringWithFormat:@"%@,%@ %@ %@",
                               measurement,
                               [tags componentsJoinedByString:@","],
@@ -436,7 +436,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     [dict setObject:start forKey:@"start"];
     [dict setObject:stop forKey:@"stop"];
-    
+
     NSError* error;
     NSData*  jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                         options:0 //because don't care about readability


### PR DESCRIPTION
Function supports the influxdb lineprotocol now, which expects a true or false string without quotes to represent boolean values. Added i identifier for long integers.

Please review for correctness of code. Using `%d` would have used floats internally in the database.