### PR TITLE
Report time zone in shift change message

### DIFF
--- a/Source/Objects/Misc Objects/OnCallList/OROnCallListModel.m
+++ b/Source/Objects/Misc Objects/OnCallList/OROnCallListModel.m
@@ -652,16 +652,52 @@ NSString* OROnCallListModelEdited           = @"OROnCallListModelEdited";
         [messageToSend appendFormat:@"The On-list has been changed.\n"];
         [messageToSend appendString:@"Here are the new shift responsibilities:\n\n"];
         
-        if([self primaryPerson])[messageToSend appendFormat:@"Primary: %@\n",[[self primaryPerson] name]];
+        if([self primaryPerson]){
+            [messageToSend appendFormat:@"Primary: %@",[[self primaryPerson] name]];
+            if([NSTimeZone timeZoneWithName:[[self primaryPerson] timezone]]){
+                [messageToSend appendFormat:@", Time Zone: %@\n",[[self primaryPerson] timezone]];
+            }
+            else if ([[[self primaryPerson] timezone] length] > 0) {
+                [messageToSend appendString:@", Time Zone: INVALID\n"];
+            }
+            else [messageToSend appendString:@", Time Zone: NOT SPECIFIED\n"];
+        }
         else [messageToSend appendString:@"Primary: NO ONE\n"];
         
-        if([self secondaryPerson])[messageToSend appendFormat:@"Secondary: %@\n",[[self secondaryPerson] name]];
+        if([self secondaryPerson]){
+            [messageToSend appendFormat:@"Secondary: %@",[[self secondaryPerson] name]];
+            if([NSTimeZone timeZoneWithName:[[self secondaryPerson] timezone]]){
+                [messageToSend appendFormat:@", Time Zone: %@\n",[[self secondaryPerson] timezone]];
+            }
+            else if ([[[self secondaryPerson] timezone] length] > 0) {
+                [messageToSend appendString:@", Time Zone: INVALID\n"];
+            }
+            else [messageToSend appendString:@", Time Zone: NOT SPECIFIED\n"];
+        }
         else [messageToSend appendString:@"Secondary: NO ONE\n"];
         
-        if([self tertiaryPerson])[messageToSend appendFormat:@"Tertiary: %@\n",[[self tertiaryPerson] name]];
+        if([self tertiaryPerson]){
+            [messageToSend appendFormat:@"Tertiary: %@",[[self tertiaryPerson] name]];
+            if([NSTimeZone timeZoneWithName:[[self tertiaryPerson] timezone]]){
+                [messageToSend appendFormat:@", Time Zone: %@\n",[[self tertiaryPerson] timezone]];
+            }
+            else if ([[[self tertiaryPerson] timezone] length] > 0) {
+                [messageToSend appendString:@", Time Zone: INVALID\n"];
+            }
+            else [messageToSend appendString:@", Time Zone: NOT SPECIFIED\n"];
+        }
         else [messageToSend appendString:@"Tertiary: NO ONE\n"];
         
-        if([self quaternaryPerson])[messageToSend appendFormat:@"Quaternary: %@\n",[[self quaternaryPerson] name]];
+        if([self quaternaryPerson]){
+            [messageToSend appendFormat:@"Quaternary: %@",[[self quaternaryPerson] name]];
+            if([NSTimeZone timeZoneWithName:[[self quaternaryPerson] timezone]]){
+                [messageToSend appendFormat:@", Time Zone: %@\n",[[self quaternaryPerson] timezone]];
+            }
+            else if ([[[self quaternaryPerson] timezone] length] > 0) {
+                [messageToSend appendString:@", Time Zone: INVALID\n"];
+            }
+            else [messageToSend appendString:@", Time Zone: NOT SPECIFIED\n"];
+        }
         else [messageToSend appendString:@"Quaternary: NO ONE\n"];
         [messageToSend appendString:@"\nThis message was sent to the entire list.\n"];
 


### PR DESCRIPTION
This PR adds each person's time zone information to the shift change message. This can be useful to quickly know everyone's time zone status, making it clear if there is going to be times when no one is actively on call.

If any user did not input a valid time zone (i.e. in the Olson database), then `INVALID` is sent. If the user left the time zone blank, then `NOT SPECIFIED` is sent. See below for example screenshots.

Here's an example On Call List:

<img width="768" alt="Screenshot 2023-04-28 at 12 24 40 PM" src="https://user-images.githubusercontent.com/35979561/235224890-1efc497f-9b12-4877-89c7-c992cf694be5.png">

Here's an example message that's sent at shift change:

<img width="439" alt="Screenshot 2023-04-28 at 12 21 48 PM" src="https://user-images.githubusercontent.com/35979561/235224880-0c03bf6e-8680-40c2-8f8d-12376c7d7fc8.png">