### PR TITLE
Remember user's previous choice of PROM Slot in 

### DIFF
--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.m
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.m
@@ -42,8 +42,10 @@
 - (void) setModel:(id)aModel
 {
     [super setModel:aModel];
+    NSInteger currentIndex = [promSlotPUButton indexOfSelectedItem];
     [promSlotPUButton removeAllItems];
     for(int i=0; i<3; i++) [promSlotPUButton addItemWithTitle:[NSString stringWithFormat:@"Slot %d", i]];
+    [promSlotPUButton selectItemAtIndex:currentIndex];
 }
 
 - (void) registerNotificationObservers


### PR DESCRIPTION
The FlashCam dialogs now keep the last selection of the user for the PROM slot, whereas before the pop up button would always default to Slot 0 (but still keep a different slot chosen behind the scenes).

@MarkHowe Could you take a quick look just to make sure this fix is done in the right spot? Thanks!

Below is an example screenshot of one of the boxes this affects.

<img width="1041" alt="Screenshot 2023-04-28 at 1 46 30 PM" src="https://user-images.githubusercontent.com/35979561/235239390-7ff321c0-7358-475e-8eca-f91829253ade.png">