### PR TITLE
Move PROM slot initialization to awakeFromNib

### DIFF
--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.h
@@ -50,6 +50,7 @@
 - (void) dealloc;
 - (void) registerNotificationObservers;
 - (void) awakeFromNib;
+- (void) populatePromSlotPopup;
 - (void) updateWindow;
 
 #pragma mark •••Interface management

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.m
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamBaseClasses/ORFlashCamCardController.m
@@ -39,15 +39,6 @@
     [super dealloc];
 }
 
-- (void) setModel:(id)aModel
-{
-    [super setModel:aModel];
-    NSInteger currentIndex = [promSlotPUButton indexOfSelectedItem];
-    [promSlotPUButton removeAllItems];
-    for(int i=0; i<3; i++) [promSlotPUButton addItemWithTitle:[NSString stringWithFormat:@"Slot %d", i]];
-    [promSlotPUButton selectItemAtIndex:currentIndex];
-}
-
 - (void) registerNotificationObservers
 {
     NSNotificationCenter* notifyCenter = [NSNotificationCenter defaultCenter];
@@ -157,7 +148,17 @@
     [hplot setLineColor:colors[0]];
     [(ORTimeAxis*) [humidityView xAxis] setStartTime:[[NSDate date] timeIntervalSince1970]];
     [hplot release];
+    
+    [self populatePromSlotPopup];
 }
+
+
+- (void) populatePromSlotPopup
+{
+    [promSlotPUButton removeAllItems];
+    for(int i=0; i<3; i++) [promSlotPUButton addItemWithTitle:[NSString stringWithFormat:@"Slot %d", i]];
+}
+
 
 - (void) updateWindow
 {


### PR DESCRIPTION
As per @MarkHowe's suggestion, moved the initialization of the PROM slot pop up button to the `awakeFromNib` method, which is a cleaner (and more proper) way of fixing this bug. Builds upon #103.

Also removed the `setModel` method altogether, as it was no longer needed after moving the code for the PROM slot.