### PR TITLE
clear compiler warnings

### DIFF
--- a/Libraries/labjack/LJM_Utilities.h
+++ b/Libraries/labjack/LJM_Utilities.h
@@ -347,7 +347,7 @@ void PrintDeviceInfo(int deviceType, int connectionType, int serialNumber,
         packetMaxBytes);
 }
 
-void WaitForUserIfWindows()
+void WaitForUserIfWindows(void)
 {
     #ifdef _WIN32
         #ifndef AUTOMATED_TEST
@@ -356,7 +356,7 @@ void WaitForUserIfWindows()
     #endif
 }
 
-void WaitForUser()
+void WaitForUser(void)
 {
     printf("Press enter to continue\n");
     getchar();
@@ -725,7 +725,7 @@ void EnableLoggingLevel(double logLevel)
         "Setting LJM_DEBUG_LOG_FILE_MAX_SIZE");
 }
 
-unsigned int GetCurrentTimeMS()
+unsigned int GetCurrentTimeMS(void)
 {
     return (int)(LJM_GetHostTick() / 1000L);
 }
@@ -796,7 +796,7 @@ int DoesDeviceHaveWiFi(int handle)
     return 0;
 }
 
-void DisplayDebugLoggingConfigurations()
+void DisplayDebugLoggingConfigurations(void)
 {
     double mode;
     int err = LJM_ReadLibraryConfigS(LJM_DEBUG_LOG_MODE, &mode);

--- a/Source/Main Dialogs/Alarms/ORAlarmCollection.m
+++ b/Source/Main Dialogs/Alarms/ORAlarmCollection.m
@@ -562,7 +562,7 @@ NSString* ORAlarmAddressChanged			  = @"ORAlarmAddressChanged";
 			if(!hostAddress){
 				NSArray* names =  [[NSHost currentHost] addresses];
 				id aName;
-				int index = 0;
+				//int index = 0;
 				NSUInteger n = [names count];
 				for(i=0;i<n;i++){
 					aName = [names objectAtIndex:i];
@@ -571,7 +571,7 @@ NSString* ORAlarmAddressChanged			  = @"ORAlarmAddressChanged";
 							hostAddress = [aName copy];
 							break;
 						}
-						index++;
+						//index++;
 					}
 				}
 			}

--- a/Source/Main Dialogs/CommandCenter/Scripting/OrcaScript.lm
+++ b/Source/Main Dialogs/CommandCenter/Scripting/OrcaScript.lm
@@ -173,7 +173,7 @@ void OrcaScripterror(char* s)
 	functionList = nil;
 }
 
-void grabString()
+    void grabString(void)
 {
 	int i=0;
 	char c;
@@ -198,7 +198,7 @@ void grabString()
 	OrcaScriptlval.cString[i] = '\0';
 }
 
-void comment()
+    void comment(void)
 {
 	//just eat comments, carefully counting lines as needed
 	char c, c1;
@@ -213,7 +213,7 @@ loop:
 	}
 }
 
-void singleLineComment()
+    void singleLineComment(void)
 {
 	//just eat comments, carefully counting lines as needed
 	char c;
@@ -225,7 +225,7 @@ void singleLineComment()
 	}
 }
 
-void yyreset_state()
+    void yyreset_state(void)
 {
 	num_lines = 0;
 	[nodeList release];

--- a/Source/Misc/SynthesizeSingleton.h
+++ b/Source/Misc/SynthesizeSingleton.h
@@ -6,9 +6,9 @@ static OR##classname* shared##classname = nil; \
 + (OR##classname*) shared##classname \
 { \
 @synchronized(self) { \
-if (shared##classname == nil) { \
-[[self alloc] init]; \
-} \
+    if (shared##classname == nil) { \
+        shared##classname = [[super allocWithZone:NULL] init];\
+    } \
 } \
 \
 return shared##classname; \
@@ -16,38 +16,9 @@ return shared##classname; \
 \
 + (id)allocWithZone:(NSZone *)zone \
 { \
-@synchronized(self) { \
-if (shared##classname == nil) { \
-shared##classname = [super allocWithZone:zone]; \
-return shared##classname; \
-} \
-} \
-\
-return nil; \
-} \
-\
-- (id)copyWithZone:(NSZone *)zone \
-{ \
-return self; \
-} \
-\
-- (id)retain \
-{ \
-return self; \
-} \
-\
-- (NSUInteger)retainCount \
-{ \
-return 0xffffffff; \
-} \
-\
-- (oneway void)release \
-{ \
-} \
-\
-- (id)autorelease \
-{ \
-return self; \
+    @synchronized(self) { \
+        return [[self shared##classname] retain];\
+    } \
 }
 
 #define SYNTHESIZE_SINGLETON_FOR_CLASS(classname) \
@@ -56,47 +27,18 @@ static classname* shared##classname = nil; \
 \
 + (classname*) shared##classname \
 { \
-@synchronized(self) { \
-if (shared##classname == nil) { \
-[[self alloc] init]; \
-} \
-} \
-\
-return shared##classname; \
-} \
+    @synchronized(self) { \
+        if (shared##classname == nil) { \
+            shared##classname = [[super allocWithZone:NULL] init];\
+        } \
+        return shared##classname; \
+    } \
+}\
 \
 + (id)allocWithZone:(NSZone *)zone \
 { \
-@synchronized(self) { \
-if (shared##classname == nil) { \
-shared##classname = [super allocWithZone:zone]; \
-return shared##classname; \
-} \
-} \
-\
-return nil; \
-} \
-\
-- (id)copyWithZone:(NSZone *)zone \
-{ \
-return self; \
-} \
-\
-- (id)retain \
-{ \
-return self; \
-} \
-\
-- (NSUInteger)retainCount\
-{ \
-return 0xffffffff; \
-} \
-\
-- (oneway void)release \
-{ \
-} \
-\
-- (id)autorelease \
-{ \
-return self; \
-}
+    @synchronized(self) { \
+        return [[self shared##classname] retain];\
+    } \
+    return nil; \
+}\

--- a/Source/Objects/Hardware/Camac/DGF4c/xiaUtilities.m
+++ b/Source/Objects/Hardware/Camac/DGF4c/xiaUtilities.m
@@ -205,7 +205,7 @@ double Thresh_Finder(unsigned int* Trace, double Tau, double* FF, double* FF2, i
 }
 
 
-int32_t RandomSwap() {
+int32_t RandomSwap(void) {
 	
 	int32_t rshift,Ncards;
 	int32_t k,MixLevel,imin,imax;


### PR DESCRIPTION
Modified the singleton framework to comply to Apple's new recommendations for singletons. This clears most of ORCA's false positive memory leak messages in the Analyzer. 

Cleared a couple of other 'C' level compiler warnings about prototypes and unused variables.