### PR TITLE
added missing retain of the header

### DIFF
--- a/Source/Objects/Data Processing/Dispatcher/ORDispatcherModel.m
+++ b/Source/Objects/Data Processing/Dispatcher/ORDispatcherModel.m
@@ -424,7 +424,7 @@ NSString* ORDispatcherLock                      = @"ORDispatcherLock";
 	runInProgress = YES;
     ignoreBlock = NO;
 	[currentHeader release];
-	currentHeader = [userInfo objectForKey:kHeader];
+    currentHeader = [[userInfo objectForKey:kHeader]retain]; //07/03/23 MAH added missing retain.
 	//[clients makeObjectsPerformSelector:@selector(writeData:) withObject:dataHeader];
 	[clients makeObjectsPerformSelector:@selector(clearCounts)];
 }


### PR DESCRIPTION
Removing a double retain a few months ago to fix a memory leak brought to light a missing retain in the data broadcaster, which caused a crash from the release of an non-retained object