### PR TITLE
ADEIControl timeout error: Add identifying info

### DIFF
--- a/Source/Objects/Hardware/Internet/ADEIControl/ORADEIControlModel.m
+++ b/Source/Objects/Hardware/Internet/ADEIControl/ORADEIControlModel.m
@@ -1547,7 +1547,7 @@ NSString* ORADEIControlLock						         = @"ORADEIControlLock";
 {
 	@synchronized (self){
 		[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(timeout) object:nil];
-		NSLogError(@"command timeout",@"ADEIControl",nil);
+		NSLogError(@"command timeout", [@"ADEIControl - " stringByAppendingString:[self title]], nil);
 		[self setLastRequest:nil];
         [stringBuffer release];
         stringBuffer = nil;


### PR DESCRIPTION
This is useful since sometimes we have this type of issue at KATRIN and immediately seeing which ADEIControl object it comes from is valuable.