### PR TITLE
Always write alarms to log

### DIFF
--- a/Source/Main Dialogs/Alarms/ORAlarmCollection.m
+++ b/Source/Main Dialogs/Alarms/ORAlarmCollection.m
@@ -241,10 +241,9 @@ SYNTHESIZE_SINGLETON_FOR_ORCLASS(AlarmCollection);
 			[alarms insertObject:anAlarm atIndex:[alarms count]];
 		}
 		[[NSNotificationCenter defaultCenter] postNotificationName:ORAlarmAddedToCollection object:anAlarm];
-		
-		NSLogColor([NSColor redColor],@" Alarm: [%@] Posted\n",[anAlarm name]);
-
     }
+		
+	NSLogColor([NSColor redColor],@" Alarm: [%@] Posted\n",[anAlarm name]);
 }
 
 - (void) removeAlarm:(ORAlarm*)anAlarm


### PR DESCRIPTION
Previously, alarms were only written to log if they were not already posted. This is confusing since this means some alarms are sent via mail but not logged if operators decide to not acknowledge an old alarm. Therefore, this commit changes the alarms so they always occur in the status log.

This is based on an issue at KATRIN where some repeated alarms are only seen by the very limited amount of people subscribed to the ORCA mail alarms. Ideally, the alarm window would show how often an alarm was posted and when it was posted first and last, similar to the already existing ORCA error log, but that is not as needed as the change done in this commit.