### PR TITLE
force 'endediting' for the metadata info field

### DIFF
--- a/Source/Experiments/LEGEND/L200/ORL200Controller.m
+++ b/Source/Experiments/LEGEND/L200/ORL200Controller.m
@@ -315,6 +315,7 @@
 
 - (void) disableRunAndPeriod
 {
+    [self endEditing];
     [dataCycleField setEnabled:NO];
     [dataPeriodField setEnabled:NO];
     [cycleStepper setEnabled:NO];
@@ -369,16 +370,19 @@
 
 - (void) dataCycleChanged:(NSNotification*) aNote
 {
+    [self endEditing];
     [dataCycleField setIntValue:[model dataCycle]];
 }
 
 - (void) dataPeriodChanged:(NSNotification*) aNote
 {
+    [self endEditing];
     [dataPeriodField setIntValue:[model dataPeriod]];
 }
 
 - (void) dataTypeChanged:(NSNotification*) aNote
 {
+    [self endEditing];
     [dataTypePopup selectItemWithTag:[model dataType]];
     if([dataTypePopup selectedTag]==32){
         [customTypeLabel setHidden:NO];
@@ -392,6 +396,7 @@
 
 - (void) customTypeChanged:(NSNotification*) aNote
 {
+    [self endEditing];
     [customTypeField setStringValue:[model customType]];
 }
 


### PR DESCRIPTION
Added an 'End Editing' call on meta data info in case the user forgot to hit Enter.