### PR TITLE
Pull minor changes from fcio and libfsp.

### DIFF
--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/fcio/fcio.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/fcio/fcio.c
@@ -970,9 +970,9 @@ static inline int fcio_get_sparseevent(FCIOStream stream, fcio_event *event, int
   }
 
   if (debug > 3) {
-    fprintf(stderr,"FCIO/fcio_get_sparseevent/DEBUG: type %d pulser %g, offset %d %d %d ",event->type,event->pulser,event->timeoffset[0],event->timeoffset[1],event->timeoffset[2]);
-    fprintf(stderr,"timestamp[%d]", event->timestamp_size); for (int i = 0; i < event->timestamp_size; i++) fprintf(stderr," %d",event->timestamp[i]);
-    fprintf(stderr,"deadregion[%d]", event->deadregion_size); for (int i = 0; i < event->deadregion_size; i++) fprintf(stderr," %d",event->deadregion[i]);
+    fprintf(stderr,"FCIO/fcio_get_sparseevent/DEBUG: type %d pulser %g, offset %d %d %d",event->type,event->pulser,event->timeoffset[0],event->timeoffset[1],event->timeoffset[2]);
+    fprintf(stderr," timestamp[%d]", event->timestamp_size); for (int i = 0; i < event->timestamp_size; i++) fprintf(stderr," %d",event->timestamp[i]);
+    fprintf(stderr," deadregion[%d]", event->deadregion_size); for (int i = 0; i < event->deadregion_size; i++) fprintf(stderr," %d",event->deadregion[i]);
     if (debug > 5) {
       fprintf(stderr," traces[%d]", event->num_traces);
       for (int i = 0; i < event->num_traces; i++) fprintf(stderr," %d",event->trace_list[i]);
@@ -1013,9 +1013,9 @@ static inline int fcio_get_eventheader(FCIOStream stream, fcio_config* config, f
   }
 
   if (debug > 3) {
-    fprintf(stderr,"FCIO/fcio_get_eventheader/DEBUG: type %d pulser %g, offset %d %d %d ",event->type,event->pulser,event->timeoffset[0],event->timeoffset[1],event->timeoffset[2]);
-    fprintf(stderr,"timestamp[%d]", event->timestamp_size); for (int i = 0; i < event->timestamp_size; i++) fprintf(stderr," %d",event->timestamp[i]);
-    fprintf(stderr,"deadregion[%d]", event->deadregion_size); for (int i = 0; i < event->deadregion_size; i++) fprintf(stderr," %d",event->deadregion[i]);
+    fprintf(stderr,"FCIO/fcio_get_eventheader/DEBUG: type %d pulser %g, offset %d %d %d",event->type,event->pulser,event->timeoffset[0],event->timeoffset[1],event->timeoffset[2]);
+    fprintf(stderr," timestamp[%d]", event->timestamp_size); for (int i = 0; i < event->timestamp_size; i++) fprintf(stderr," %d",event->timestamp[i]);
+    fprintf(stderr," deadregion[%d]", event->deadregion_size); for (int i = 0; i < event->deadregion_size; i++) fprintf(stderr," %d",event->deadregion[i]);
     if (debug > 5) {
       fprintf(stderr," traces[%d]", event->num_traces);
       for (int i = 0; i < event->num_traces; i++)

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/dsp.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/dsp.h
@@ -11,20 +11,20 @@ typedef struct DSPWindowedPeakSum {
   float thresholds[FCIOMaxChannels];
   float lowpass[FCIOMaxChannels];
   int shaping_widths[FCIOMaxChannels];
-  int dsp_pre_samples[FCIOMaxChannels];
-  int dsp_post_samples[FCIOMaxChannels];
+  int dsp_margin_front[FCIOMaxChannels];
+  int dsp_margin_back[FCIOMaxChannels];
   int dsp_start_sample[FCIOMaxChannels];
   int dsp_stop_sample[FCIOMaxChannels];
-  int dsp_pre_max_samples;
-  int dsp_post_max_samples;
+  int dsp_max_margin_front;
+  int dsp_max_margin_back;
 
   int apply_gain_scaling;
 
   // unsigned int repetition;
-  int coincidence_window;
+  int sum_window_size;
   int sum_window_start_sample;
   int sum_window_stop_sample;
-  float coincidence_threshold;
+  float sub_event_sum_threshold;
 
   float peak_trace[FCIOMaxSamples];
   float diff_trace[FCIOMaxSamples];
@@ -57,20 +57,20 @@ typedef struct DSPWindowedPeakSum {
 
 } DSPWindowedPeakSum;
 
-typedef struct DSPHardwareMajority {
+typedef struct DSPHardwareMultiplicity {
   FSPTraceMap tracemap;
   unsigned short fpga_energy_threshold_adc[FCIOMaxChannels];
 
   int fast;
   /* result fields */
   int multiplicity; // multiplicity of hardware energy values
-  int mult_below_threshold; // counts the number of channels below fpga_energy_threshold_adc but > 0
+  int n_below_minimum_multiplicity; // counts the number of channels below fpga_energy_threshold_adc but > 0
   unsigned short max_value; // the largest channel hw value
   unsigned short min_value; // the smallest channel hw value, but > 0
 
   int enabled;
 
-} DSPHardwareMajority;
+} DSPHardwareMultiplicity;
 
 typedef struct DSPChannelThreshold {
   FSPTraceMap tracemap;
@@ -101,7 +101,7 @@ float fsp_dsp_local_peaks_f32(float *input_trace, float *peak_trace, int start, 
                                float *peak_amplitudes, int *npeaks, int* largest_peak_offset);
 
 void fsp_dsp_windowed_peak_sum(DSPWindowedPeakSum *cfg, int nsamples, int num_traces, unsigned short* trace_list, unsigned short **traces);
-void fsp_dsp_hardware_majority(DSPHardwareMajority *cfg, int num_traces, unsigned short* trace_list, unsigned short **trace_headers);
+void fsp_dsp_hardware_majority(DSPHardwareMultiplicity *cfg, int num_traces, unsigned short* trace_list, unsigned short **trace_headers);
 void fsp_dsp_channel_threshold(DSPChannelThreshold* cfg, int nsamples, int num_traces, unsigned short* trace_list, unsigned short **traces, unsigned short **theaders);
 
 

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/flags.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/flags.h
@@ -6,8 +6,8 @@ typedef union TriggerFlags {
   struct {
     uint8_t hwm_multiplicity; // the multiplicity threshold has been reached
     uint8_t hwm_prescaled; // the event was prescaled due to the HWM condition
-    uint8_t wps_abs; // the absolute peak sum threshold was reached
-    uint8_t wps_rel; // the relative peak sum threshold was reached and a coincidence to a reference event is fulfilled
+    uint8_t wps_sum; // the standalone peak sum threshold was reached
+    uint8_t wps_coincident_sum; // the coincidence peak sum threshold was reached and a coincidence to a reference event is fulfilled
     uint8_t wps_prescaled; // the event was prescaled due to the WPS condition
     uint8_t ct_multiplicity; // a channel was above the ChannelThreshold condition
   };
@@ -16,8 +16,8 @@ typedef union TriggerFlags {
 
 typedef union EventFlags {
   struct {
-    uint8_t is_retrigger; // the event is a retrigger event
-    uint8_t is_extended; // the event triggered (a) retrigger event(s)
+    uint8_t consecutive; // the event might be a retrigger event or start immediately after
+    uint8_t extended; // the event preceeds one or more consecutive events
   };
   uint64_t is_flagged;
 } EventFlags;
@@ -25,11 +25,11 @@ typedef union EventFlags {
 // Windowed Peak Sum
 typedef union WPSFlags {
   struct {
-    uint8_t abs_threshold; // absolute threshold was reached
-    uint8_t rel_threshold; // relative threshold was reached
-    uint8_t rel_reference; // the event is a WPS reference event
-    uint8_t rel_pre_window; // the event is in the pre window of a reference event
-    uint8_t rel_post_window; // the event is in the post window of a reference event
+    uint8_t sum_threshold; // sum threshold was reached
+    uint8_t coincidence_sum_threshold; // coincidence sum threshold was reached
+    uint8_t coincidence_ref; // the event is a WPS reference event
+    uint8_t ref_pre_window; // the event is in the pre window of a reference event
+    uint8_t ref_post_window; // the event is in the post window of a reference event
     uint8_t prescaled; // in addition to the multiplicity_below condition the current event is ready to prescale to it's timestamp
   };
   uint64_t is_flagged;

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/io.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/io.c
@@ -14,9 +14,9 @@ static inline size_t event_flag_2char(char* string, size_t strlen, EventFlags ev
   int written = 0;
 
   string[written++] = ':';
-  if (event_flags.is_retrigger)
+  if (event_flags.consecutive)
     string[written] = 'R';
-  if (event_flags.is_extended)
+  if (event_flags.extended)
     string[written] = 'E';
 
   written++;
@@ -53,15 +53,15 @@ static inline size_t wps_flag_2char(char* string, size_t strlen, WPSFlags wps_fl
 
   int written = 0;
   string[written++] = ':';
-  if (wps_flags.rel_reference) string[written] = '!' ;
+  if (wps_flags.coincidence_ref) string[written] = '!' ;
   written++;
-  if (wps_flags.rel_post_window) string[written] = '<' ;
+  if (wps_flags.ref_post_window) string[written] = '<' ;
   written++;
-  if (wps_flags.rel_threshold) string[written] = '-' ;
+  if (wps_flags.coincidence_sum_threshold) string[written] = '-' ;
   written++;
-  if (wps_flags.rel_pre_window) string[written] = '>' ;
+  if (wps_flags.ref_pre_window) string[written] = '>' ;
   written++;
-  if (wps_flags.abs_threshold) string[written] = 'A';
+  if (wps_flags.sum_threshold) string[written] = 'A';
   written++;
   return written;
 }
@@ -77,9 +77,9 @@ static inline size_t st_flag_2char(char* string, size_t strlen, TriggerFlags st_
   written++;
   if (st_flags.hwm_prescaled) string[written] = 'G' ;
   written++;
-  if (st_flags.wps_abs) string[written] = 'A' ;
+  if (st_flags.wps_sum) string[written] = 'A' ;
   written++;
-  if (st_flags.wps_rel) string[written] = 'C' ;
+  if (st_flags.wps_coincident_sum) string[written] = 'C' ;
   written++;
   if (st_flags.wps_prescaled) string[written] = 'S' ;
   written++;
@@ -142,18 +142,18 @@ void FSPFlags2BitField(FSPState* fsp_state, uint32_t* trigger_field, uint32_t* e
 
   tfield |= ((fsp_state->write_flags.trigger.hwm_multiplicity & 0x1) << 0);
   tfield |= ((fsp_state->write_flags.trigger.hwm_prescaled & 0x1)    << 1);
-  tfield |= ((fsp_state->write_flags.trigger.wps_abs & 0x1)          << 2);
-  tfield |= ((fsp_state->write_flags.trigger.wps_rel & 0x1)          << 3);
+  tfield |= ((fsp_state->write_flags.trigger.wps_sum & 0x1)          << 2);
+  tfield |= ((fsp_state->write_flags.trigger.wps_coincident_sum & 0x1)          << 3);
   tfield |= ((fsp_state->write_flags.trigger.wps_prescaled & 0x1)    << 4);
   tfield |= ((fsp_state->write_flags.trigger.ct_multiplicity & 0x1)  << 5);
 
-  efield |= ((fsp_state->write_flags.event.is_extended & 0x1)          << 0);
-  efield |= ((fsp_state->write_flags.event.is_retrigger & 0x1)         << 1);
-  efield |= ((fsp_state->proc_flags.wps.abs_threshold & 0x1)          << 2);
-  efield |= ((fsp_state->proc_flags.wps.rel_threshold & 0x1)          << 3);
-  efield |= ((fsp_state->proc_flags.wps.rel_reference & 0x1)          << 4);
-  efield |= ((fsp_state->proc_flags.wps.rel_pre_window & 0x1)         << 5);
-  efield |= ((fsp_state->proc_flags.wps.rel_post_window & 0x1)        << 6);
+  efield |= ((fsp_state->write_flags.event.extended & 0x1)          << 0);
+  efield |= ((fsp_state->write_flags.event.consecutive & 0x1)         << 1);
+  efield |= ((fsp_state->proc_flags.wps.sum_threshold & 0x1)          << 2);
+  efield |= ((fsp_state->proc_flags.wps.coincidence_sum_threshold & 0x1)          << 3);
+  efield |= ((fsp_state->proc_flags.wps.coincidence_ref & 0x1)          << 4);
+  efield |= ((fsp_state->proc_flags.wps.ref_pre_window & 0x1)         << 5);
+  efield |= ((fsp_state->proc_flags.wps.ref_post_window & 0x1)        << 6);
   efield |= ((fsp_state->proc_flags.hwm.multiplicity_threshold & 0x1) << 7);
   efield |= ((fsp_state->proc_flags.hwm.multiplicity_below & 0x1)     << 8);
   efield |= ((fsp_state->proc_flags.ct.multiplicity & 0x1)            << 9);
@@ -166,18 +166,18 @@ void FSPBitField2Flags(FSPState* fsp_state, uint32_t trigger_field, uint32_t eve
 {
   fsp_state->write_flags.trigger.hwm_multiplicity =  trigger_field & (0x1 << 0);
   fsp_state->write_flags.trigger.hwm_prescaled =     trigger_field & (0x1 << 1);
-  fsp_state->write_flags.trigger.wps_abs =           trigger_field & (0x1 << 2);
-  fsp_state->write_flags.trigger.wps_rel =           trigger_field & (0x1 << 3);
+  fsp_state->write_flags.trigger.wps_sum =           trigger_field & (0x1 << 2);
+  fsp_state->write_flags.trigger.wps_coincident_sum =           trigger_field & (0x1 << 3);
   fsp_state->write_flags.trigger.wps_prescaled =     trigger_field & (0x1 << 4);
   fsp_state->write_flags.trigger.ct_multiplicity =   trigger_field & (0x1 << 5);
 
-  fsp_state->write_flags.event.is_extended =           event_field & (0x1 << 0);
-  fsp_state->write_flags.event.is_retrigger =          event_field & (0x1 << 1);
-  fsp_state->proc_flags.wps.abs_threshold =           event_field & (0x1 << 2);
-  fsp_state->proc_flags.wps.rel_threshold =           event_field & (0x1 << 3);
-  fsp_state->proc_flags.wps.rel_reference =           event_field & (0x1 << 4);
-  fsp_state->proc_flags.wps.rel_pre_window =          event_field & (0x1 << 5);
-  fsp_state->proc_flags.wps.rel_post_window =         event_field & (0x1 << 6);
+  fsp_state->write_flags.event.extended =           event_field & (0x1 << 0);
+  fsp_state->write_flags.event.consecutive =          event_field & (0x1 << 1);
+  fsp_state->proc_flags.wps.sum_threshold =           event_field & (0x1 << 2);
+  fsp_state->proc_flags.wps.coincidence_sum_threshold =           event_field & (0x1 << 3);
+  fsp_state->proc_flags.wps.coincidence_ref =           event_field & (0x1 << 4);
+  fsp_state->proc_flags.wps.ref_pre_window =          event_field & (0x1 << 5);
+  fsp_state->proc_flags.wps.ref_post_window =         event_field & (0x1 << 6);
   fsp_state->proc_flags.hwm.multiplicity_threshold =  event_field & (0x1 << 7);
   fsp_state->proc_flags.hwm.multiplicity_below =      event_field & (0x1 << 8);
   fsp_state->proc_flags.ct.multiplicity =             event_field & (0x1 << 9);
@@ -194,21 +194,21 @@ void FSPFlags2BitString(FSPState* fsp_state, size_t strlen, char* trigger_string
   *trgstring-- = 0;
   *trgstring-- = (fsp_state->write_flags.trigger.hwm_multiplicity & 0x1) ? '1' : '0';
   *trgstring-- = (fsp_state->write_flags.trigger.hwm_prescaled & 0x1) ? '1' : '0';
-  *trgstring-- = (fsp_state->write_flags.trigger.wps_abs & 0x1) ? '1' : '0';
-  *trgstring-- = (fsp_state->write_flags.trigger.wps_rel & 0x1) ? '1' : '0';
+  *trgstring-- = (fsp_state->write_flags.trigger.wps_sum & 0x1) ? '1' : '0';
+  *trgstring-- = (fsp_state->write_flags.trigger.wps_coincident_sum & 0x1) ? '1' : '0';
   *trgstring-- = (fsp_state->write_flags.trigger.wps_prescaled & 0x1) ? '1' : '0';
   *trgstring-- = (fsp_state->write_flags.trigger.ct_multiplicity & 0x1) ? '1' : '0';
   *trgstring-- = 'b';
   *trgstring = '0';
 
   *evtstring-- = 0;
-  *evtstring-- = (fsp_state->write_flags.event.is_extended & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->write_flags.event.is_retrigger & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->proc_flags.wps.abs_threshold & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->proc_flags.wps.rel_threshold & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->proc_flags.wps.rel_reference & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->proc_flags.wps.rel_pre_window & 0x1) ? '1' : '0';
-  *evtstring-- = (fsp_state->proc_flags.wps.rel_post_window & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->write_flags.event.extended & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->write_flags.event.consecutive & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->proc_flags.wps.sum_threshold & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->proc_flags.wps.coincidence_sum_threshold & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->proc_flags.wps.coincidence_ref & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->proc_flags.wps.ref_pre_window & 0x1) ? '1' : '0';
+  *evtstring-- = (fsp_state->proc_flags.wps.ref_post_window & 0x1) ? '1' : '0';
   *evtstring-- = (fsp_state->proc_flags.hwm.multiplicity_threshold & 0x1) ? '1' : '0';
   *evtstring-- = (fsp_state->proc_flags.hwm.multiplicity_below & 0x1) ? '1' : '0';
   *evtstring-- = (fsp_state->proc_flags.ct.multiplicity & 0x1) ? '1' : '0';

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
@@ -11,9 +11,9 @@ typedef struct {
 
 // Windows Peak Sum
 typedef struct wps_obs {
-  float max_value; // what is the maximum peak amplitude sum within the integration windows
-  int max_offset;  // which sample offset is max_value at?
-  int max_multiplicity;  // How many channels did have a peak above thresholds
+  float sum_value; // what is the maximum peak amplitude sum within the integration windows
+  int sum_offset;  // which sample offset is max_value at?
+  int sum_multiplicity;  // How many channels did have a peak above thresholds
   float max_single_peak_value;   // which one was the largest individual peak
   int max_single_peak_offset;  // which sample contains this peak
 } wps_obs;
@@ -36,7 +36,7 @@ typedef struct ct_obs {
 
 // Event Stream
 typedef struct evt_obs {
-  int nextension; // if we found re-triggers how many events are consecutive from then on. the event with the extension flag carries the total number
+  int nconsecutive; // if we found re-triggers how many events are consecutive from then on. the event with the extension flag carries the total number
 } evt_obs;
 
 typedef struct FSPObervables {

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.c
@@ -93,8 +93,8 @@ StreamProcessor* FSPCreate(unsigned int buffer_depth)
   processor->wps_prescale_timestamp.seconds = -1; // will init when it's needed
 
   /* hardcoded defaults which should make sense. Used SetFunctions outside to overwrite */
-  FSPEnableEventFlags(processor, (EventFlags){ .is_retrigger = 1, .is_extended = 1});
-  FSPEnableTriggerFlags(processor, (TriggerFlags){ .hwm_multiplicity = 1, .hwm_prescaled = 1, .wps_abs = 1, .wps_rel = 1, .wps_prescaled = 1, .ct_multiplicity = 1} );
+  FSPEnableEventFlags(processor, (EventFlags){ .consecutive = 1, .extended = 1});
+  FSPEnableTriggerFlags(processor, (TriggerFlags){ .hwm_multiplicity = 1, .hwm_prescaled = 1, .wps_sum = 1, .wps_coincident_sum = 1, .wps_prescaled = 1, .ct_multiplicity = 1} );
 
   HWMFlags ref_hwm = {0};
   ref_hwm.multiplicity_threshold = 1;
@@ -155,12 +155,12 @@ static inline void fsp_derive_triggerflags(StreamProcessor* processor, FSPState*
   if (processor->triggerconfig.enabled_flags.trigger.ct_multiplicity && fsp_state->proc_flags.ct.multiplicity)
     fsp_state->write_flags.trigger.ct_multiplicity = 1;
 
-  if (processor->triggerconfig.enabled_flags.trigger.wps_abs && fsp_state->proc_flags.wps.abs_threshold)
-    fsp_state->write_flags.trigger.wps_abs = 1;
+  if (processor->triggerconfig.enabled_flags.trigger.wps_sum && fsp_state->proc_flags.wps.sum_threshold)
+    fsp_state->write_flags.trigger.wps_sum = 1;
 
-  if (processor->triggerconfig.enabled_flags.trigger.wps_rel && fsp_state->proc_flags.wps.rel_threshold)
-    if (fsp_state->proc_flags.wps.rel_pre_window || fsp_state->proc_flags.wps.rel_post_window) {
-      fsp_state->write_flags.trigger.wps_rel = 1;
+  if (processor->triggerconfig.enabled_flags.trigger.wps_coincident_sum && fsp_state->proc_flags.wps.coincidence_sum_threshold)
+    if (fsp_state->proc_flags.wps.ref_pre_window || fsp_state->proc_flags.wps.ref_post_window) {
+      fsp_state->write_flags.trigger.wps_coincident_sum = 1;
     }
 
   if (processor->triggerconfig.enabled_flags.trigger.hwm_prescaled && fsp_state->proc_flags.hwm.prescaled)

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.h
@@ -10,22 +10,30 @@
 
 typedef struct {
 
-  int hwm_threshold;
+  int hwm_min_multiplicity;
   int hwm_prescale_ratio;
   int wps_prescale_ratio;
 
-  float relative_wps_threshold;
-  float absolute_wps_threshold;
+  float wps_coincident_sum_threshold;
+  float wps_sum_threshold;
   float wps_prescale_rate;
   float hwm_prescale_rate;
 
+  // the write flags which trigger the final `write` decision after
+  // all processing
   FSPWriteFlags enabled_flags;
+  // the window before and after a reference event
+  // the WPS event above wps_coincident_sum_threshold will trigger a wps_coincident_sum flagging
   Timestamp pre_trigger_window;
   Timestamp post_trigger_window;
 
+  // the processor flags that determine which event
+  // is treated as  reference event for the coincidence
+  // trigger for WPS triggering.
   HWMFlags wps_ref_flags_hwm;
   CTFlags wps_ref_flags_ct;
   WPSFlags wps_ref_flags_wps;
+  // the reference channels if CT referencing was enabled
   int n_wps_ref_map_idx;
   int wps_ref_map_idx[FCIOMaxChannels];
 
@@ -65,7 +73,7 @@ typedef struct StreamProcessor {
   // dsp and trigger configuration: written to FSPConfig
   FSPTriggerConfig triggerconfig;
   DSPWindowedPeakSum dsp_wps;
-  DSPHardwareMajority dsp_hwm;
+  DSPHardwareMultiplicity dsp_hwm;
   DSPChannelThreshold dsp_ct;
 
   // processor statistics: written to FSPStatus

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/tracemap.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/tracemap.h
@@ -6,12 +6,21 @@
 typedef struct {
   int format; // contains the format of the channel map. For processors it must be converted to trace_idx
 
-  int map[FCIOMaxChannels]; // the list of mapped traces for this processor, up to n_mapped
-  int n_mapped; // the number of mapped traces, applies to trace_list
+  // this struct provides back-and-forth lookups between the fcio_event trace_list array
+  // and the list of trace_idx handled by this processor.
+  // n_mapped is equal to the number of trace assigned to this processor
+  // and map contains a list of trace_idx's
+  //
+  // the enabled array has the same sizes as fcio_config.tracemap
+  // with entrys either -1 for traces not handled by this processor or the index into the `map` array
+  // which allows a loopup of the correct trace_idx
 
-  // reverse lookup for mapped channels:
+  int map[FCIOMaxChannels]; // the list of assigned traces for this processor, up to n_mapped
+  int n_mapped; // the number of assigned traces, applies to trace_list
+
+  // reverse lookup for mapped channels.
   int enabled[FCIOMaxChannels]; // a list of map_idx, index with trace_idx from fcio_event.trace_list
-  int n_enabled; // the total number of traces available, must equal fcio_config.adcs
+  int n_enabled; // the total number of traces available, is equal to fcio_config.adcs. If 0 the processer was not enabled.
 
    // a human readable label, index similar to `map`.
   char label[FCIOMaxChannels][8];
@@ -19,16 +28,16 @@ typedef struct {
 } FSPTraceMap;
 
 typedef enum FSPTraceFormat {
-  FCIO_TRACE_INDEX_FORMAT = 0,
-  FCIO_TRACE_MAP_FORMAT = 1,
-  L200_RAWID_FORMAT = 2,
-  FSPTraceFormatUnkown = 3
+  FSPTraceFormatUnkown = 0,
+  FCIO_TRACE_INDEX_FORMAT = 1,
+  FCIO_TRACE_MAP_FORMAT = 2,
+  L200_RAWID_FORMAT = 3
 
 } FSPTraceFormat;
 
 static inline int is_known_channelmap_format(FSPTraceFormat format)
 {
-  return (format < FSPTraceFormatUnkown) ? 1 : 0;
+  return (format != FSPTraceFormatUnkown) ? 1 : 0;
 }
 
 static inline const char* channelmap_fmt2str(FSPTraceFormat format)


### PR DESCRIPTION
Two debug statements in fcio had a missing whitespace.

Some variables in libfsp have been renamed for clarity.

Both changes are very minor and do not change any functionality.