### PR TITLE
Added printing information about run start exceptions

### DIFF
--- a/Source/Misc/Utilities.h
+++ b/Source/Misc/Utilities.h
@@ -50,6 +50,10 @@ NSString* launchPath(void);
 NSString* fullVersion(void);
 NSString* gitRevHash(void);
 
+// Get human readable exception stack trace
+// Usage: e.g. NSLog(@"Stack trace:\n%@\n",getStackTrace([myCaughtException callStackSymbols]));
+NSString* getStackTrace(NSArray<NSString *> *callStackSymbols);
+
 //alert panels for 10.10 and before
 BOOL ORRunAlertPanel(NSString* mainMessage, NSString* informativeMessage, NSString* defaultButtonTitle, NSString* alternateButtonTitle, NSString* otherButtonTitle, ...);
 

--- a/Source/Objects/Control/RunControl/ORRunModel.m
+++ b/Source/Objects/Control/RunControl/ORRunModel.m
@@ -26,6 +26,7 @@
 #import "ORDataTypeAssigner.h"
 #import "ORRunScriptModel.h"
 #import "ORDecoder.h"
+#import "Utilities.h"
 
 #pragma mark ¥¥¥Definitions
 
@@ -1386,13 +1387,15 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
         
 		if(!runFailedAlarm){
 			runFailedAlarm = [[ORAlarm alloc] initWithName:[NSString stringWithFormat:@"Run %u did NOT start",[self runNumber]] severity:kRunInhibitorAlarm];
+            
 			[runFailedAlarm setSticky:YES];
 		}
 		[runFailedAlarm setAcknowledged:NO];
 		[runFailedAlarm postAlarm];
         
-        //NSLogColor([NSColor redColor],@"Run Not Started because of exception: %@\n",[localException name]);
-        NSLogColor([NSColor redColor],@"Run Not Started because of exception: %@, reason: %@\n",[localException name],[localException reason]);//please show more info -tb-
+        // Log error information and stack trace
+        NSLogColor([NSColor redColor],@"Run Not Started because of exception: %@, reason: %@\n\n",[localException name],[localException reason]);
+        NSLog(@"Exception stack trace:\n%@\n",getStackTrace([localException callStackSymbols]));
         
     }
 }


### PR DESCRIPTION
Added printing information about run start exceptions, also providing a general function to print stack traces.

Stack traces are needed since at KATRIN we regularly see an exception that we don't understand yet. Also it addresses the long outstanding and with this commit removed comment asking for more information on the error.

Note that since acquiring the stack trace takes a moment, if there are other high-frequent messages in the status log, they might get printed in between the "Run Not Started because of exception" and the following stack trace.

Example output in the status log:

```
30.03.25 01:32:13  Alarm: [Run 6 did NOT start] Posted
30.03.25 01:32:13 Run Not Started because of exception: Not Connected, reason: Socket not connected.

30.03.25 01:32:13 Exception stack trace:
0   CoreFoundation                      0x00007ff810557326 __exceptionPreprocess + 242
1   libobjc.A.dylib                     0x00007ff81003cbd0 objc_exception_throw + 62
2   CoreFoundation                      0x00007ff8105571c4 +[NSException raise:format:] + 228
3   Orca                                0x0000000104faa89b -[ORKatrinV4SLTModel(private) read:] + 91
4   Orca                                0x000000010486bce7 -[ORIpeCard read:] + 71
5   Orca                                0x0000000104b56e47 -[ORKatrinV4FLTModel readReg:] + 71
6   Orca                                0x0000000104b561b6 -[ORKatrinV4FLTModel readVersion] + 38
7   Orca                                0x0000000104b59e1a -[ORKatrinV4FLTModel addParametersToDictionary:] + 2090
8   Orca                                0x00000001046e2f91 -[ORCard addObjectInfoToArray:] + 65
9   Orca                                0x00000001046e47f5 -[ORCrate addObjectInfoToArray:] + 565
10  Orca                                0x0000000104486241 -[ORDocument fillInHeaderInfo:] + 1521
11  Orca                                0x00000001044fe05b -[ORDataPacket makeFileHeader] + 107
12  Orca                                0x0000000104578012 -[ORRunModel runStarted:] + 274
13  Orca                                0x0000000104575a1a -[ORRunModel startRunStage3:] + 234
14  Orca                                0x0000000104575860 -[ORRunModel startRunStage2:] + 240
15  Foundation                          0x00007ff81153e7c0 __NSFireDelayedPerform + 438
16  CoreFoundation                      0x00007ff8104ff70e __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
17  CoreFoundation                      0x00007ff8104ff2bc __CFRunLoopDoTimer + 801
18  CoreFoundation                      0x00007ff8104feee8 __CFRunLoopDoTimers + 285
19  CoreFoundation                      0x00007ff8104e5b73 __CFRunLoopRun + 2261
20  CoreFoundation                      0x00007ff8104e4c6e CFRunLoopRunSpecific + 550
21  HIToolbox                           0x00007ff81bcec413 RunCurrentEventLoopInMode + 292
22  HIToolbox                           0x00007ff81bcf1d63 ReceiveNextEventCommon + 501
23  HIToolbox                           0x00007ff81bcf2029 _BlockUntilNextEventMatchingListInModeWithFilter + 66
24  AppKit                              0x00007ff813e47b33 _DPSNextEvent + 902
25  AppKit                              0x00007ff81489c8b8 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1290
26  AppKit                              0x00007ff813e38aa9 -[NSApplication run] + 610
27  AppKit                              0x00007ff813e0bd34 NSApplicationMain + 823
28  Orca                                0x0000000104474e15 main + 117
29  dyld                                0x00007ff8100712cd start + 1805
```