### PR TITLE
Refactor of Hardware Multiplicity (GE) in libfsp

### DIFF
--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/ORFlashCamListenerModel.m
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/ORFlashCamListenerModel.m
@@ -1348,7 +1348,6 @@ NSString* ORFlashCamListenerModelSWTConfigChanged    = @"ORFlashCamListenerModel
     if ([self configParam:@"fspHWEnabled"] && nfspHWChannels) {
         if (!FSP_L200_SetGeParameters(processor, nfspHWChannels, fspHWChannelMap, FCIO_TRACE_MAP_FORMAT,
                                 [[self configParam:@"fspHWMajThreshold"] intValue],
-                                0, // do not skip any channels to check
                                 fspHWPrescaleThresholds,
                                 [[self configParam:@"fspHWPreScaleRatio"] intValue])) {
             NSLogColor([NSColor redColor], @"%@: setupSoftwareTrigger: Error parsing HW Multiplicity parameters.\n", [self identifier]);

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/buffer.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/buffer.c
@@ -1,9 +1,7 @@
 #include "buffer.h"
 
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <stdio.h>
 

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/dsp.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/dsp.h
@@ -58,13 +58,17 @@ typedef struct DSPWindowedPeakSum {
 } DSPWindowedPeakSum;
 
 typedef struct DSPHardwareMultiplicity {
+  /* configuration */
   FSPTraceMap tracemap;
   unsigned short fpga_energy_threshold_adc[FCIOMaxChannels];
 
-  int fast;
+  /* tmp values */
+  int below_threshold_counter[FCIOMaxChannels]; // counts the number of events eligible for prescaling
+
   /* result fields */
-  int multiplicity; // multiplicity of hardware energy values
-  int n_below_minimum_multiplicity; // counts the number of channels below fpga_energy_threshold_adc but > 0
+  int n_hw_trg; // multiplicity of hardware energy values / non-zero == triggered
+  int n_sw_trg; // multiplicity of hw energy > sw threshold
+
   unsigned short max_value; // the largest channel hw value
   unsigned short min_value; // the smallest channel hw value, but > 0
 

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/flags.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/flags.h
@@ -30,7 +30,7 @@ typedef union WPSFlags {
     uint8_t coincidence_ref; // the event is a WPS reference event
     uint8_t ref_pre_window; // the event is in the pre window of a reference event
     uint8_t ref_post_window; // the event is in the post window of a reference event
-    uint8_t prescaled; // in addition to the multiplicity_below condition the current event is ready to prescale to it's timestamp
+    uint8_t prescaled; // the event was prescaled
   };
   uint64_t is_flagged;
 } WPSFlags;
@@ -38,9 +38,9 @@ typedef union WPSFlags {
 // Hardware Multiplicity
 typedef union HWMFlags {
   struct {
-    uint8_t multiplicity_threshold; // the multiplicity threshold (number of channels) has been reached
-    uint8_t multiplicity_below; // all non-zero channels have an hardware value below the set amplitude threshold
-    uint8_t prescaled; // in addition to the multiplicity_below condition the current event is ready to prescale to it's timestamp
+    uint8_t sw_multiplicity; // the multiplicity threshold for number of sw triggered channels has been reached
+    uint8_t hw_multiplicity; // the multiplicity threshold for number of hw triggered channels has been reached
+    uint8_t prescaled; // a channel was prescaled
   };
   uint64_t is_flagged;
 } HWMFlags;

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/io_fcio.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/io_fcio.c
@@ -1,13 +1,14 @@
 #include "io_fcio.h"
 #include "dsp.h"
 #include "fcio.h"
-#include "fsp/observables.h"
+#include "observables.h"
 #include "processor.h"
 #include "state.h"
 #include "timestamps.h"
 
 #include <fcio_utils.h>
 #include <tmio.h>
+#include <unistd.h>
 
 /* internal helpers */
 
@@ -25,8 +26,11 @@ static inline int fcio_get_fsp_tracemap(FCIOStream stream, FSPTraceMap* map) {
   if (!stream || !map)
     return -1;
   FCIOReadInt(stream, map->format);
-  map->n_mapped = FCIOReadInts(stream, FCIOMaxChannels, map->map) / sizeof(*map->map);
-  map->n_enabled = FCIOReadInts(stream, FCIOMaxChannels, map->enabled) / sizeof(*map->enabled);
+  int readbytes = 0;
+  readbytes = FCIOReadInts(stream, FCIOMaxChannels, map->map);
+  map->n_mapped = (readbytes >= 0) ? readbytes/sizeof(*map->map) : 0;
+  readbytes = FCIOReadInts(stream, FCIOMaxChannels, map->enabled);
+  map->n_enabled = (readbytes >= 0) ? readbytes/sizeof(*map->enabled) : 0;
   int nlabels = FCIORead(stream, FCIOMaxChannels * sizeof(*map->label), map->label) / sizeof(*map->label);
 
   if (nlabels != map->n_mapped)
@@ -204,7 +208,9 @@ static inline int fcio_get_fspconfig_trigger(FCIOStream stream, FSPTriggerConfig
   FCIORead(stream, sizeof(HWMFlags), &config->wps_ref_flags_hwm);
   FCIORead(stream, sizeof(CTFlags), &config->wps_ref_flags_ct);
   FCIORead(stream, sizeof(WPSFlags), &config->wps_ref_flags_wps);
-  config->n_wps_ref_map_idx = FCIOReadInts(stream, FCIOMaxChannels, config->wps_ref_map_idx)/sizeof(int);
+
+  int readbytes = FCIOReadInts(stream, FCIOMaxChannels, config->wps_ref_map_idx);
+  config->n_wps_ref_map_idx = (readbytes >= 0) ? readbytes/sizeof(int) : 0;
 
   return 0;
 }
@@ -275,6 +281,7 @@ int FCIOGetFSPEvent(FCIOData* input, StreamProcessor* processor)
     return -1;
 
   FSPState* fsp_state = processor->fsp_state;
+  int readbytes = 0;
 
   FCIOStream in = FCIOStreamHandle(input);
   FCIORead(in, sizeof(fsp_state->write_flags), &fsp_state->write_flags);
@@ -284,14 +291,17 @@ int FCIOGetFSPEvent(FCIOData* input, StreamProcessor* processor)
   FCIORead(in, sizeof(fsp_state->obs.hwm), &fsp_state->obs.hwm);
   FCIORead(in, sizeof(fsp_state->obs.wps), &fsp_state->obs.wps);
 
-  fsp_state->obs.ct.multiplicity = FCIOReadInts(in, FCIOMaxChannels, fsp_state->obs.ct.trace_idx)/sizeof(int);
+  readbytes = FCIOReadInts(in, FCIOMaxChannels, fsp_state->obs.ct.trace_idx);
+  fsp_state->obs.ct.multiplicity = (readbytes >= 0) ? readbytes/sizeof(int) : 0;
   FCIOReadUShorts(in, FCIOMaxChannels, fsp_state->obs.ct.max);
 
-  fsp_state->obs.sub_event_list.size = FCIOReadInts(in, FCIOMaxSamples, fsp_state->obs.sub_event_list.start)/sizeof(int);
+  readbytes = FCIOReadInts(in, FCIOMaxSamples, fsp_state->obs.sub_event_list.start);
+  fsp_state->obs.sub_event_list.size = (readbytes >= 0) ? readbytes/sizeof(int) : 0;
   FCIOReadInts(in, FCIOMaxSamples, fsp_state->obs.sub_event_list.stop);
   FCIOReadFloats(in, FCIOMaxSamples, fsp_state->obs.sub_event_list.wps_max);
 
-  fsp_state->obs.ps.n_hwm_prescaled = FCIOWriteInts(in, FCIOMaxChannels, fsp_state->obs.ps.hwm_prescaled_trace_idx);
+  readbytes = FCIOReadInts(in, FCIOMaxChannels, fsp_state->obs.ps.hwm_prescaled_trace_idx);
+  fsp_state->obs.ps.n_hwm_prescaled = (readbytes >= 0) ? readbytes/sizeof(int) : 0;
 
   return 0;
 }
@@ -462,7 +472,7 @@ static inline size_t fspevent_size(FSPState* fspstate) {
   total_size += frame_header + sizeof(*((SubEventList){0}).start) * fspstate->obs.sub_event_list.size;
   total_size += frame_header + sizeof(*((SubEventList){0}).stop) * fspstate->obs.sub_event_list.size;
   total_size += frame_header + sizeof(*((SubEventList){0}).wps_max) * fspstate->obs.sub_event_list.size;
-  total_size += frame_header + sizeof(*((prescaler_obs){0}).hwm_prescaled_trace_idx) * fspstate->obs.ps.n_hwm_prescaled;
+  total_size += frame_header + sizeof(*((prescale_obs){0}).hwm_prescaled_trace_idx) * fspstate->obs.ps.n_hwm_prescaled;
 
   return total_size;
 }

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
@@ -61,7 +61,7 @@ typedef struct prescale_obs {
   // which channels were prescaled
   unsigned short hwm_prescaled_trace_idx[FCIOMaxChannels];
 
-} prescaler_obs;
+} prescale_obs;
 
 typedef struct FSPObervables {
 
@@ -69,7 +69,7 @@ typedef struct FSPObervables {
   hwm_obs hwm;
   ct_obs ct;
   evt_obs evt;
-  prescaler_obs ps;
+  prescale_obs ps;
 
   SubEventList sub_event_list;
 

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/observables.h
@@ -4,40 +4,64 @@
 
 typedef struct {
     int size;
+    // first sample the trigger is up
     int start[FCIOMaxSamples];
-    int stop[FCIOMaxSamples]; // first sample after trigger up is gone
+    // first sample after trigger up is gone
+    int stop[FCIOMaxSamples];
     float wps_max[FCIOMaxSamples];
   } SubEventList;
 
 // Windows Peak Sum
 typedef struct wps_obs {
-  float sum_value; // what is the maximum peak amplitude sum within the integration windows
-  int sum_offset;  // which sample offset is max_value at?
-  int sum_multiplicity;  // How many channels did have a peak above thresholds
-  float max_single_peak_value;   // which one was the largest individual peak
-  int max_single_peak_offset;  // which sample contains this peak
+  // what is the maximum peak amplitude sum within the integration windows
+  float sum_value;
+  // which sample offset is max_value at?
+  int sum_offset;
+  // How many channels did have a peak above thresholds
+  int sum_multiplicity;
+  // which one was the largest individual peak
+  float max_single_peak_value;
+  // which sample contains this peak
+  int max_single_peak_offset;
 } wps_obs;
 
 // FPGA Majority
 typedef struct hwm_obs {
-  int multiplicity;          // how many channels have fpga_energy > 0
-  unsigned short max_value;  // what is the largest fpga_energy of those
-  unsigned short min_value;  // what is the smallest fpga_energy of those
+  // how many channels have fpga_energy > 0
+  int hw_multiplicity;
+  // what is the largest fpga_energy of those
+  unsigned short max_value;
+  // what is the smallest fpga_energy of those
+  unsigned short min_value;
+  // how many channels were above the fpga_energy threshold in software trigger and the required multiplicity
+  int sw_multiplicity;
 
 } hwm_obs;
 
 // Channel Threshold
 typedef struct ct_obs {
-  int multiplicity; // how many channels were above the threshold
-  int trace_idx[FCIOMaxChannels]; // the corresponding fcio trace index
-  unsigned short max[FCIOMaxChannels]; // the maximum per channel
+  // how many channels were above the threshold
+  int multiplicity;
+  // the corresponding fcio trace index
+  int trace_idx[FCIOMaxChannels];
+  // the maximum per channel
+  unsigned short max[FCIOMaxChannels];
 
 } ct_obs;
 
 // Event Stream
 typedef struct evt_obs {
-  int nconsecutive; // if we found re-triggers how many events are consecutive from then on. the event with the extension flag carries the total number
+  // if we found re-triggers how many events are consecutive from then on. the event with the extension flag carries the total number
+  int nconsecutive;
 } evt_obs;
+
+typedef struct prescale_obs {
+  // how many hwm channels were prescaled
+  int n_hwm_prescaled;
+  // which channels were prescaled
+  unsigned short hwm_prescaled_trace_idx[FCIOMaxChannels];
+
+} prescaler_obs;
 
 typedef struct FSPObervables {
 
@@ -45,6 +69,7 @@ typedef struct FSPObervables {
   hwm_obs hwm;
   ct_obs ct;
   evt_obs evt;
+  prescaler_obs ps;
 
   SubEventList sub_event_list;
 

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.c
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.c
@@ -87,17 +87,18 @@ StreamProcessor* FSPCreate(unsigned int buffer_depth)
 
     processor->dsp_wps.tracemap.map[i] = -1;
     processor->dsp_wps.tracemap.enabled[i] = -1;
+    
+    processor->prescaler.hwm_prescale_timestamp[i].seconds = -1; // will init when it's needed
   }
 
-  processor->hwm_prescale_timestamp.seconds = -1; // will init when it's needed
-  processor->wps_prescale_timestamp.seconds = -1; // will init when it's needed
+  processor->prescaler.wps_prescale_timestamp.seconds = -1; // will init when it's needed
 
   /* hardcoded defaults which should make sense. Used SetFunctions outside to overwrite */
   FSPEnableEventFlags(processor, (EventFlags){ .consecutive = 1, .extended = 1});
   FSPEnableTriggerFlags(processor, (TriggerFlags){ .hwm_multiplicity = 1, .hwm_prescaled = 1, .wps_sum = 1, .wps_coincident_sum = 1, .wps_prescaled = 1, .ct_multiplicity = 1} );
 
   HWMFlags ref_hwm = {0};
-  ref_hwm.multiplicity_threshold = 1;
+  ref_hwm.sw_multiplicity = 1;
   CTFlags ref_ct = {0};
   WPSFlags ref_wps = {0};
   FSPSetWPSReferences(processor, ref_hwm, ref_ct, ref_wps, NULL, 0);
@@ -144,13 +145,11 @@ static inline void fsp_derive_triggerflags(StreamProcessor* processor, FSPState*
   /*
     This function calculates the trigger flag fields from the individual processor flags
   */
-  if (processor->triggerconfig.enabled_flags.trigger.hwm_multiplicity && fsp_state->proc_flags.hwm.multiplicity_threshold)
+  if (processor->triggerconfig.enabled_flags.trigger.hwm_multiplicity && fsp_state->proc_flags.hwm.sw_multiplicity)
     fsp_state->write_flags.trigger.hwm_multiplicity = 1;
 
-  if (processor->triggerconfig.enabled_flags.trigger.hwm_prescaled && fsp_state->proc_flags.hwm.prescaled) {
-    fsp_state->write_flags.trigger.hwm_multiplicity = 0;
+  if (processor->triggerconfig.enabled_flags.trigger.hwm_prescaled && fsp_state->proc_flags.hwm.prescaled)
     fsp_state->write_flags.trigger.hwm_prescaled = 1;
-  }
 
   if (processor->triggerconfig.enabled_flags.trigger.ct_multiplicity && fsp_state->proc_flags.ct.multiplicity)
     fsp_state->write_flags.trigger.ct_multiplicity = 1;
@@ -162,9 +161,6 @@ static inline void fsp_derive_triggerflags(StreamProcessor* processor, FSPState*
     if (fsp_state->proc_flags.wps.ref_pre_window || fsp_state->proc_flags.wps.ref_post_window) {
       fsp_state->write_flags.trigger.wps_coincident_sum = 1;
     }
-
-  if (processor->triggerconfig.enabled_flags.trigger.hwm_prescaled && fsp_state->proc_flags.hwm.prescaled)
-    fsp_state->write_flags.trigger.hwm_prescaled = 1;
 
   if (processor->triggerconfig.enabled_flags.trigger.wps_prescaled && fsp_state->proc_flags.wps.prescaled)
     fsp_state->write_flags.trigger.wps_prescaled = 1;

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp/processor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fcio.h"
 #include "timestamps.h"
 #include "flags.h"
 #include "stats.h"
@@ -11,13 +12,13 @@
 typedef struct {
 
   int hwm_min_multiplicity;
-  int hwm_prescale_ratio;
-  int wps_prescale_ratio;
+  int hwm_prescale_ratio[FCIOMaxChannels]; // the per channel prescale ratio
+  float hwm_prescale_rate[FCIOMaxChannels];
 
+  int wps_prescale_ratio;
   float wps_coincident_sum_threshold;
   float wps_sum_threshold;
   float wps_prescale_rate;
-  float hwm_prescale_rate;
 
   // the write flags which trigger the final `write` decision after
   // all processing
@@ -39,6 +40,19 @@ typedef struct {
 
 } FSPTriggerConfig;
 
+typedef struct {
+
+  int enabled;
+
+  int wps_prescale_ready_counter;
+  Timestamp wps_prescale_timestamp;
+  Timestamp hwm_prescale_timestamp[FCIOMaxChannels];
+
+  int n_hwm_prescaled; // counts the number of channels that were prescaled
+  int hwm_prescaled_trace_idx[FCIOMaxChannels]; // the list of trace_idx which were prescaled
+
+} FSPPrescaler;
+
 typedef struct StreamProcessor {
 
   // run-time configuration
@@ -59,12 +73,6 @@ typedef struct StreamProcessor {
   Timestamp post_trigger_timestamp;
   Timestamp pre_trigger_timestamp;
 
-  int wps_prescale_ready_counter;
-  Timestamp wps_prescale_timestamp;
-
-  int hwm_prescale_ready_counter;
-  Timestamp hwm_prescale_timestamp;
-
   // buffer configuration: written to FSPConfig
   Timestamp minimum_buffer_window;
   unsigned int minimum_buffer_depth;
@@ -75,6 +83,7 @@ typedef struct StreamProcessor {
   DSPWindowedPeakSum dsp_wps;
   DSPHardwareMultiplicity dsp_hwm;
   DSPChannelThreshold dsp_ct;
+  FSPPrescaler prescaler;
 
   // processor statistics: written to FSPStatus
   FSPStats stats;

--- a/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp_l200.h
+++ b/Source/Objects/Hardware/Internet/FlashCam/FlashCamIO/libfsp/fsp_l200.h
@@ -47,7 +47,7 @@ int FSP_L200_SetAuxParameters(StreamProcessor *processor, FSPTraceFormat format,
                         int digital_muon_channel, int muon_level_adc);
 
 int FSP_L200_SetGeParameters(StreamProcessor *processor, int nchannels, int *channelmap, FSPTraceFormat format,
-                       int majority_threshold, int skip_full_counting, unsigned short *ge_prescaling_threshold_adc,
+                       int majority_threshold, unsigned short *ge_prescaling_threshold_adc,
                        int prescale_ratio);
 
 int FSP_L200_SetSiPMParameters(StreamProcessor *processor, int nchannels, int *channelmap, FSPTraceFormat format,


### PR DESCRIPTION
Pulls changes from libfsp:
- write prescaled channel indices for GE subsystem in non-sparse. Only relevant if prescaling is used in `phy` but this PR prepares for the possibility.
- Remove superfluous includes
- Adds a flag which indicating hw and sw triggers separately
- Adds observable which counts multiplicity of hw and sw triggers separately
- Refine comments for observables in header files.

This PR should be merged before usage of the Software Trigger to have a consistent dataformat. It is backwards compatible to the previous data taken, but adds additional information.
