### PR TITLE
Limit  the icon sizes.

### DIFF
--- a/Source/Misc/ORToolbarFactory.m
+++ b/Source/Misc/ORToolbarFactory.m
@@ -98,6 +98,11 @@
 		tbi = [[[NSToolbarItem alloc] initWithItemIdentifier: itemIdentifier] autorelease];
 		[tbi setAction: itemAction];
 		[tbi setLabel: itemLabel];
+        
+        //------ MAH set size to limit image sizes, which changed with a recent OS update ----
+        [itemImage setSize:NSMakeSize(35,35)];
+        //------
+        
 		[tbi setImage: itemImage];
 		if(itemCustomLabel) [tbi setPaletteLabel: itemCustomLabel];
 		else				[tbi setPaletteLabel: itemLabel];


### PR DESCRIPTION
The tool bar icon sizes where no longer reasonable sizes as of a couple of OS updates ago. Now limit size to 35x35 pixels